### PR TITLE
Fix GLUT include, update Model and Rig class

### DIFF
--- a/AnimRig.cpp
+++ b/AnimRig.cpp
@@ -26,7 +26,7 @@ void Rig::drawRig() {
 	};
 	glPushMatrix();
 	//the model at pos 0 in modelParts is the root
-	glTranslatef(modelParts[0].x, modelParts[0].y, modelParts[0].z);
+	glTranslatef(modelParts[0].pivotX, modelParts[0].pivotY, modelParts[0].pivotZ);
 	glRotatef(modelParts[0].rotX, 1.0, 0.0, 0.0);
 	glRotatef(modelParts[0].rotY, 0.0, 1.0, 0.0);
 	glRotatef(modelParts[0].rotZ, 0.0, 0.0, 1.0);
@@ -46,16 +46,16 @@ void Rig::recursiveDraw(deque<Model*> childModels) {
 		};
 		glPushMatrix();
 		glTranslatef(
-			(*childModels.front()).x,
-			(*childModels.front()).y,
-			(*childModels.front()).z);
+			(*childModels.front()).pivotX + (*childModels.front()).x,
+			(*childModels.front()).pivotY + (*childModels.front()).y,
+			(*childModels.front()).pivotZ + (*childModels.front()).z);
 		glRotatef((*childModels.front()).rotX, 1.0, 0.0, 0.0);
 		glRotatef((*childModels.front()).rotY, 0.0, 1.0, 0.0);
 		glRotatef((*childModels.front()).rotZ, 0.0, 0.0, 1.0);
 		glTranslatef(
-			-(*childModels.front()).x,
-			-(*childModels.front()).y,
-			-(*childModels.front()).z);
+			-(*childModels.front()).pivotX,
+			-(*childModels.front()).pivotY,
+			-(*childModels.front()).pivotZ);
 		(*childModels.front()).drawNonTextured(colorArray);		
 		Model *placeHolder = childModels.front();
 		childModels.pop_front();

--- a/ReadObj.cpp
+++ b/ReadObj.cpp
@@ -8,9 +8,9 @@ Model::Model(string objSource,
 	childNames = children;
 	name = objSource.substr(0, objSource.length() - 4);
 	rotX = rotY = rotZ = 0;
-	x = _x;
-	y = _y;
-	z = _z;
+	pivotX = _x;
+	pivotY = _y;
+	pivotZ = _z;
 	drawNormals = false;
 	ifstream source;
 	source.open(objSource, ios::in);

--- a/ReadObj.h
+++ b/ReadObj.h
@@ -54,6 +54,7 @@ public:
 	vector<vector<double>> normVectors;
 	vector<vector<double>> textureCoords;
 	bool drawNormals;
-	//x, y, and z store the position of the pivot point in the model
-	float x, y, z, rotX, rotY, rotZ;
+	//pivotX, pivotY, and pivotZ store the position of the pivot point in the model
+	//while x, y, and z store the corresponding offset for moving that part of the model specifically
+	float pivotX, pivotY, pivotZ, x = 0, y = 0, z = 0, rotX, rotY, rotZ;
 };

--- a/ReadObj.h
+++ b/ReadObj.h
@@ -15,7 +15,7 @@ texture tutorial
 #include <iostream>
 #include <string>
 #include <sstream>
-#include <glut/GLUT.H>
+#include <GLUT/GLUT.H>
 using namespace std;
 
 /*


### PR DESCRIPTION
Made the GLUT include statement in ReadObj.h all caps, updated Model and Rig classes to use pivot point coordinates so the moveModel function works properly.